### PR TITLE
Update Flet dependency to 0.27.6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -236,6 +236,7 @@ for:
   - echo "LOG_LEVEL=TRACE" >> .env
   - mv "./assets/icon-beta.png" "./assets/icon.png" 2>/dev/null
   - curl https://$MATCH_DEPLOY_KEY@raw.githubusercontent.com/kumpeapps/android_certs/main/kumpe3dkiosk -o /tmp/kumpe3dkiosk
+  - ls /tmp
   - flet build apk --build-version "${APPVEYOR_REPO_TAG_NAME:-"2.3.7"}" --build-number $APPVEYOR_BUILD_NUMBER --android-signing-key-password $MATCH_KEYCHAIN_PASSWORD --android-signing-key-store-password $MATCH_KEYCHAIN_PASSWORD --android-signing-key-store /tmp/kumpe3dkiosk --android-signing-key-alias upload --flutter-build-args=--debug
 
   after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -217,7 +217,7 @@ for:
   - path: kumpe3dkiosk-ios.tar.gz
 
 #
-#   Android package - BETA 
+#   Android package - BETA
 # 
 -
   branches:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 
 
 dependencies = [
-  "flet==0.27.5",
+  "flet==0.27.6",
   "PyMySQL==1.1.1",
   "python-dotenv==1.0.1",
   "parse==1.20.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flet==0.27.5
+flet==0.27.6
 PyMySQL==1.1.1
 python-dotenv==1.0.1
 parse==1.20.1


### PR DESCRIPTION
## Summary by Sourcery

Updates Flet dependency to version 0.27.6 and lists the contents of /tmp in the CI build.

Build:
- Lists the contents of /tmp in the CI build.
- Updates Flet dependency to version 0.27.6

Chores:
- Updates Flet dependency to version 0.27.6